### PR TITLE
Add Flask service entry point

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+from flask import Flask, jsonify
+
+from dibbs_scraper import scrape_dibbs
+
+app = Flask(__name__)
+
+@app.route("/")
+def index():
+    return (
+        "DIBBS Scraper Service is running.\n"
+        "Use GET /scrape/<solicitation_number> to retrieve data."
+    )
+
+@app.route("/scrape/<string:solicitation>")
+def scrape(solicitation):
+    try:
+        result = scrape_dibbs(solicitation)
+        return jsonify(result)
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.1.1
+requests==2.32.3
+beautifulsoup4==4.13.4
+gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- provide minimal Flask API wrapping existing `scrape_dibbs`
- specify required dependencies
- add Procfile for Gunicorn on Heroku

## Testing
- `python -m py_compile app.py`
- `python -m py_compile dibbs_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_683f51cb8b40833386d92e94608e0ffc