### PR TITLE
Add Streamlit interface and DB utilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,44 +1,43 @@
-"""Streamlit web interface for the DIBBS scraper and AI tools."""
+"""Streamlit interface for scraping and analyzing DIBBS solicitations."""
 
-import pandas as pd
 import streamlit as st
 
-from dibbs_scraper import scrape_latest
-from database import init_db, insert_solicitation, fetch_all
-from ai_utils import summarize_solicitation, generate_email
-
-# Initialize database on startup
-init_db()
+from scraper import run_scraper
+from db_utils import fetch_solicitations, get_solicitation_details
+from openai_utils import summarize_solicitation, generate_outreach_email
 
 st.set_page_config(page_title="DIBBS Scraper", layout="wide")
 
 st.title("DIBBS Scraper and Analyzer")
 
-if st.button("Scrape Latest Solicitations"):
-    with st.spinner("Scraping..."):
-        items = scrape_latest(limit=5)
-        for item in items:
-            insert_solicitation(item)
-        st.success(f"Scraped {len(items)} items and stored them in the database.")
+# Run scraper button
+if st.button("Run Scraper"):
+    st.write("Scraping DIBBS...")
+    run_scraper()
+    st.success("Scraping complete!")
 
-# Fetch data from database
-solicitations = fetch_all()
-if solicitations:
-    df = pd.DataFrame(solicitations)
-    st.subheader("Stored Solicitations")
-    st.dataframe(df)
+# Filter inputs
+filter_fsc = st.text_input("Filter by FSC")
+filter_nsn = st.text_input("Filter by NSN")
 
-    selected = st.selectbox(
-        "Select a solicitation for AI analysis",
-        options=df["solicitation"],
-    )
-    record = next((s for s in solicitations if s["solicitation"] == selected), None)
-    if record:
-        if st.button("Summarize Solicitation"):
-            summary = summarize_solicitation(record.get("description", ""))
-            st.write(summary)
-        if st.button("Generate Outreach Email"):
-            email = generate_email(record)
-            st.text_area("Draft Email", value=email, height=200)
+data = fetch_solicitations(filter_fsc, filter_nsn)
+
+if data:
+    options = [row["solicitation"] for row in data]
+    selected = st.selectbox("Select a Solicitation", options)
+    selected_data = get_solicitation_details(selected)
+
+    st.write("### Solicitation Details")
+    st.json(selected_data)
+
+    if st.button("Summarize with GPT"):
+        summary = summarize_solicitation(selected_data.get("description", ""))
+        st.write("#### GPT Summary")
+        st.write(summary)
+
+    if st.button("Generate Outreach Email"):
+        email = generate_outreach_email(selected_data)
+        st.write("#### Draft Email")
+        st.code(email)
 else:
-    st.info("No data available. Click 'Scrape Latest Solicitations' to begin.")
+    st.write("No solicitations found.")

--- a/database.py
+++ b/database.py
@@ -18,6 +18,9 @@ def init_db() -> None:
             description TEXT,
             deadline TEXT,
             buyer TEXT,
+            nsn TEXT,
+            fsc TEXT,
+            posted TEXT,
             raw_data TEXT
         )
         """
@@ -31,14 +34,18 @@ def insert_solicitation(data: Dict) -> None:
     conn = sqlite3.connect(DB_PATH)
     conn.execute(
         """
-        INSERT OR IGNORE INTO solicitations (solicitation, description, deadline, buyer, raw_data)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT OR IGNORE INTO solicitations (
+            solicitation, description, deadline, buyer, nsn, fsc, posted, raw_data
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             data.get("solicitation"),
             data.get("description"),
             data.get("deadline"),
             data.get("buyer"),
+            data.get("nsn"),
+            data.get("fsc"),
+            data.get("posted"),
             json.dumps(data),
         ),
     )
@@ -50,11 +57,11 @@ def fetch_all() -> List[Dict]:
     """Return all solicitations stored in the database."""
     conn = sqlite3.connect(DB_PATH)
     rows = conn.execute(
-        "SELECT solicitation, description, deadline, buyer, raw_data FROM solicitations"
+        "SELECT solicitation, description, deadline, buyer, nsn, fsc, posted, raw_data FROM solicitations"
     ).fetchall()
     conn.close()
     result = []
-    for solicitation, description, deadline, buyer, raw_json in rows:
+    for solicitation, description, deadline, buyer, nsn, fsc, posted, raw_json in rows:
         item = json.loads(raw_json)
         item.update(
             {
@@ -62,6 +69,9 @@ def fetch_all() -> List[Dict]:
                 "description": description,
                 "deadline": deadline,
                 "buyer": buyer,
+                "nsn": nsn,
+                "fsc": fsc,
+                "posted": posted,
             }
         )
         result.append(item)

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,39 @@
+import sqlite3
+from typing import List, Dict, Optional
+
+DB_PATH = "solicitations.db"
+
+
+def fetch_solicitations(fsc: str = "", nsn: str = "", start_date: str = "", end_date: str = "") -> List[Dict]:
+    """Return solicitations filtered by FSC, NSN, and optional posted date range."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    query = "SELECT solicitation, description, deadline, buyer, nsn, fsc, posted FROM solicitations WHERE 1=1"
+    params = []
+    if fsc:
+        query += " AND fsc LIKE ?"
+        params.append(f"%{fsc}%")
+    if nsn:
+        query += " AND nsn LIKE ?"
+        params.append(f"%{nsn}%")
+    if start_date:
+        query += " AND posted >= ?"
+        params.append(start_date)
+    if end_date:
+        query += " AND posted <= ?"
+        params.append(end_date)
+    rows = conn.execute(query, params).fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
+def get_solicitation_details(solicitation: str) -> Optional[Dict]:
+    """Return the full record for a specific solicitation."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT solicitation, description, deadline, buyer, nsn, fsc, posted FROM solicitations WHERE solicitation = ?",
+        (solicitation,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None

--- a/dibbs_scraper.py
+++ b/dibbs_scraper.py
@@ -40,12 +40,18 @@ def scrape_latest(limit: int = 5) -> List[Dict]:
             description = cells[1].inner_text().strip()
             deadline = cells[2].inner_text().strip()
             buyer = cells[3].inner_text().strip()
+            nsn = cells[4].inner_text().strip() if len(cells) > 4 else ""
+            fsc = cells[5].inner_text().strip() if len(cells) > 5 else ""
+            posted = cells[6].inner_text().strip() if len(cells) > 6 else ""
             results.append(
                 {
                     "solicitation": solicitation,
                     "description": description,
                     "deadline": deadline,
                     "buyer": buyer,
+                    "nsn": nsn,
+                    "fsc": fsc,
+                    "posted": posted,
                 }
             )
         browser.close()
@@ -66,12 +72,18 @@ def scrape_solicitation_detail(solicitation: str) -> Dict:
         description = page.locator(".description").inner_text()
         deadline = page.locator(".deadline").inner_text()
         buyer = page.locator(".buyer").inner_text()
+        nsn = page.locator(".nsn").inner_text() if page.locator(".nsn").count() else ""
+        fsc = page.locator(".fsc").inner_text() if page.locator(".fsc").count() else ""
+        posted = page.locator(".posted").inner_text() if page.locator(".posted").count() else ""
         browser.close()
         return {
             "solicitation": solicitation,
             "description": description.strip(),
             "deadline": deadline.strip(),
             "buyer": buyer.strip(),
+            "nsn": nsn.strip(),
+            "fsc": fsc.strip(),
+            "posted": posted.strip(),
         }
 
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,0 +1,41 @@
+"""Helper functions that wrap OpenAI's GPT API for summaries and emails."""
+import os
+from typing import Dict
+
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+SUMMARY_PROMPT = (
+    "You are an expert in government procurement. "
+    "Provide a concise summary of the following solicitation:\n{solicitation}"
+)
+
+EMAIL_PROMPT = (
+    "You are a helpful assistant tasked with drafting a short outreach email to a vendor.\n"
+    "Solicitation info: {solicitation}.\n"
+    "Write a professional email requesting a quote and referencing the solicitation number."
+)
+
+
+def summarize_solicitation(text: str) -> str:
+    """Summarize the solicitation text using GPT."""
+    if not openai.api_key:
+        return "[OpenAI API key not configured]"
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": SUMMARY_PROMPT.format(solicitation=text)}],
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+def generate_outreach_email(data: Dict) -> str:
+    """Generate an email for the given solicitation record."""
+    if not openai.api_key:
+        return "[OpenAI API key not configured]"
+    solicitation_text = f"Solicitation {data.get('solicitation')} - {data.get('description')}"
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": EMAIL_PROMPT.format(solicitation=solicitation_text)}],
+    )
+    return resp.choices[0].message["content"].strip()

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,11 @@
+"""Wrapper to run the DIBBS scraper and store results."""
+from dibbs_scraper import scrape_latest
+from database import init_db, insert_solicitation
+
+
+def run_scraper(limit: int = 5) -> None:
+    """Scrape latest solicitations and store them in the database."""
+    init_db()
+    items = scrape_latest(limit=limit)
+    for item in items:
+        insert_solicitation(item)


### PR DESCRIPTION
## Summary
- extend database to track nsn/fsc/posted fields
- provide helpers for scraping results into the DB
- add new wrappers for OpenAI summarization and email drafting
- create utility functions to query solicitations by filter
- update `app.py` to include Run Scraper button and GPT actions

## Testing
- `python -m pip install -r requirements.txt` *(fails: dependency conflict)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f7646a1348333acc7bf4dbb6d6861